### PR TITLE
add cv parameter

### DIFF
--- a/content/content-delivery/en/core-resources/links/retrieve-multiple-links.md
+++ b/content/content-delivery/en/core-resources/links/retrieve-multiple-links.md
@@ -10,6 +10,7 @@ Returns the links object containing all links of one space. Use the `version` pa
 | `starts_with` | Filter by `full_slug`. Can be used to retrieve all links form a specific folder. Examples: `starts_with=de/beitraege`, `starts_with=en/posts` | 
 | `version` | Default: `published`. Possible values: `draft`, `published` |
 | `paginated` | Set this to `1` if you want to retrieve the paginated results. With the parameters `per_page` and `page` you can define the page size and page number |
+| `cv` | Read more about cache version at [Cache invalidation](#topics/cache-invalidation) |
 
 Attention: This API endpoint is not paged.
 


### PR DESCRIPTION
As far as I can tell, the cv parameter also works here, but is not documented.

Also, it seems to be set to the same default always. If I don't set it, I always get the same outdated version of the links.