### PR TITLE
Update overview.md

### DIFF
--- a/content/content-delivery/v2/filter-queries/overview.md
+++ b/content/content-delivery/v2/filter-queries/overview.md
@@ -28,7 +28,7 @@ By default the applied filters are connected by the AND operator but it is also 
 
 ```javascript
 StoryblokClient.get('cdn/stories', {
-  filter_query_v2: {
+  filter_query: {
     __or: [
       { color: { in: 'red' } },
       { background: { in: 'blue' } }


### PR DESCRIPTION
We found you were using `filter_query_v2` which wasn't usable, assumed this was part of the transition from v1 to v2 and the documentation wasn't updated. My change just changed it to `filter_query`.