### PR TITLE
fixes typo disble in MAPI docs

### DIFF
--- a/content/management/v1/core-resources/stories/create-story.md
+++ b/content/management/v1/core-resources/stories/create-story.md
@@ -13,7 +13,7 @@ You can set most of the fields that are available in the story object, below we 
 | `story[default_root]` (required*) | Default content type/root component. (*Required if `is_folder` is `true`) |
 | `story[is_folder]` | If `true` a folder will be created instead of a story |
 | `story[parent_id]` | The id of the parent |
-| `story[disble_fe_editor]` | Is side by side editor disabled for all entries in folder (true/false) |
+| `story[disable_fe_editor]` | Is side by side editor disabled for all entries in folder (true/false) |
 | `story[path]` | Given real path, used in the preview editor |
 | `story[is_startpage]` | Is startpage of current folder (true/false) |
 | `story[position]` | Integer value of the position |

--- a/content/management/v1/core-resources/stories/the-story-object.md
+++ b/content/management/v1/core-resources/stories/the-story-object.md
@@ -20,7 +20,7 @@ This is an object representing your content entry. One Story object can be of a 
 | `is_startpage`        | Is startpage of current folder (true/false) | 
 | `is_folder`           | Is story a folder (true/false) | 
 | `default_root`        | Component name which will be used as default content type for this folders entries |
-| `disble_fe_editor`    | Is side by side editor disabled for all entries in folder (true/false) |
+| `disable_fe_editor`    | Is side by side editor disabled for all entries in folder (true/false) |
 | `parent_id`           | Parent story/folder numeric id | 
 | `parent`              | Essential parent information as object (resolved from `parent_id`) | 
 | `group_id`            | Alternates group id (uuid string) | 
@@ -70,7 +70,7 @@ Example Object
     },
     "path": null,
     "default_root": null,
-    "disble_fe_editor": false,
+    "disable_fe_editor": false,
     // parent folder id
     "parent_id": 369683,
     // resolved parent folder information
@@ -78,7 +78,7 @@ Example Object
       "id": 369683,
       "slug": "posts",
       "name": "Posts",
-      "disble_fe_editor": true,
+      "disable_fe_editor": true,
       "uuid": "dcfcc350-e63e-4232-8dcb-ba4b8e70799d"
     },
     "full_slug": "posts/my-third-post", // automatically generated
@@ -87,7 +87,7 @@ Example Object
       "id": 369683,
       "name": "Posts",
       "parent_id": 0,
-      "disble_fe_editor": true
+      "disable_fe_editor": true
     }],
     "published": false,
     "unpublished_changes": true,

--- a/content/management/v1/core-resources/stories/update-story.md
+++ b/content/management/v1/core-resources/stories/update-story.md
@@ -13,7 +13,7 @@ Can be used to build migrations, updates if you changed your component structure
 | `story[default_root]` (required*) | Default content type/root component. (*Required if `is_folder` is `true`) |
 | `story[is_folder]` | If `true` a folder will be created instead of a story |
 | `story[parent_id]` | The id of the parent |
-| `story[disble_fe_editor]` | Is side by side editor disabled for all entries in folder (true/false) |
+| `story[disable_fe_editor]` | Is side by side editor disabled for all entries in folder (true/false) |
 | `story[path]` | Given real path, used in the preview editor |
 | `story[is_startpage]` | Is startpage of current folder (true/false) |
 | `story[position]` | Integer value of the position |


### PR DESCRIPTION
I've fixed typos of "disble" to "disable" in 3 documentation files.
- [content/management/v1/core-resources/stories/create-story.md](https://github.com/storyblok/storyblok-docs/compare/master...schabibi1:master#diff-4b0e7872ad0123a4b7fcb5c85cf2bd1ae0d12a68b85acfdcccebda7ee383d79e)
- [content/management/v1/core-resources/stories/the-story-object.md](https://github.com/storyblok/storyblok-docs/compare/master...schabibi1:master#diff-e9d3cb5a09b9e51f4699e01625a7ad2e3b9a2cdc58197450f19728c935c34f4c)
- [content/management/v1/core-resources/stories/update-story.md](https://github.com/storyblok/storyblok-docs/compare/master...schabibi1:master#diff-97f30d569ed3f7cbe18bab06143b8d742568eaca92e409fdc23f1fe2f233c0d7)

@DominikAngerer Could you check that just in case? :)