### PR TITLE
Property correction on space_role endpoint

### DIFF
--- a/content/management/v1/core-resources/space-roles/create-space-role.md
+++ b/content/management/v1/core-resources/space-roles/create-space-role.md
@@ -5,7 +5,7 @@ title: Create a Space Role
 | Property | Description |
 |---|---|
 | `space_role` | Your [space role object](#core-resources/space-roles/the-space-role-object) |
-| `space_role[name]` | The space role name is **required** |
+| `space_role[role]` | The space role name is **required** |
 
 ;examplearea
 

--- a/content/management/v1/core-resources/space-roles/update-space-role.md
+++ b/content/management/v1/core-resources/space-roles/update-space-role.md
@@ -5,7 +5,7 @@ title: Update a Space Role
 | Property | Description |
 |---|---|
 | `space_role` | Your full [component object](#core-resources/space-roles/the-space-role-object) |
-| `space_role[name]` | The space role name is **required** |
+| `space_role[role]` | The space role name is **required** |
 
 ;examplearea
 


### PR DESCRIPTION
The property "name" doesn't exist in the post/put space_roles endpoint, the correct is "role" like this payload: {"space_role":{"role":"test"}}