### PR TITLE
Update stories.md to reflect that the v1 included the url throws a 401 error.

### DIFF
--- a/content/management/v1/core-resources/stories/stories.md
+++ b/content/management/v1/core-resources/stories/stories.md
@@ -9,5 +9,5 @@ The stories endpoint will let you manage all content entries of your Storyblok s
 Endpoint
 
 ```bash
-GET /v1/spaces/:space_id/stories/:story_id
+GET /spaces/:space_id/stories/:story_id
 ```


### PR DESCRIPTION
In attempting to use the Storyblok client in node.js, I discovered that the v1 that was prefixed in the documentation was throwing a 404 error.