### PR TITLE
Update management authentication - remove bearer-prefix

### DIFF
--- a/content/management/v1/topics/authentication.md
+++ b/content/management/v1/topics/authentication.md
@@ -9,11 +9,10 @@ Your personal access token will grant anyone who obtains it with access to all a
 Using an OAuth2 token, a username and password doesn’t need to be permanently stored and you can revoke access at any time.
 
 ### Authorization for Apps
-In order to	Authenticate your Apps, make sure to add `Bearer` in front of your OAuth2 token.
 
 Examples
 ```bash
-curl -H "Authorization: Bearer YOUR_OAUTH_TOKEN" https://mapi.storyblok.com/
+curl -H "Authorization: YOUR_OAUTH_TOKEN" https://mapi.storyblok.com/
 ```
 ```javascript
 // npm install storyblok-js-client
@@ -21,7 +20,7 @@ const StoryblokClient = require('storyblok-js-client')
 
 // Initialize the client with the oauth token
 const Storyblok = new StoryblokClient({
-  oauthToken: 'Bearer YOUR_OAUTH_TOKEN'
+  oauthToken: 'YOUR_OAUTH_TOKEN'
 })
 ```
 


### PR DESCRIPTION
I was fooled by the docs telling me to prefix the OAuth Token with Bearer, which was not the case. After looking into the code of "storyblok-js-client" I found out that there was not any Bearer-prefix, and tried without the Bearer token, with success.