### PR TITLE
Update the-story-object.md

### DIFF
--- a/content/content-delivery/v2/core-resources/stories/the-story-object.md
+++ b/content/content-delivery/v2/core-resources/stories/the-story-object.md
@@ -20,7 +20,7 @@ This is an object representing your content entry. One Story object can be of a 
 | `content`             | Your defined custom content body object | 
 | `position`            | Position in folder | 
 | `is_startpage`        | Is startpage of current folder (true/false) | 
-| `parent_id`           | Parent folder id | 
+| `parent_id`           | Parent folder id (default: null on Storyblok V2) | 
 | `group_id`            | Alternates group id (uuid string) | 
 | `alternates`          | Array of alternate objects | 
 | `translated_slugs`    | Array of translated slugs. Only gets included if the translatable slug app is installed and `true` if the slug is published | 


### PR DESCRIPTION
updated that parent_id is default null on Storyblok V2