### PR TITLE
Update duplicate-space.md with `assign_partner` param

### DIFF
--- a/content/management/v1/core-resources/spaces/duplicate-space.md
+++ b/content/management/v1/core-resources/spaces/duplicate-space.md
@@ -12,6 +12,7 @@ Duplicate a space and all it's content entries and components; Assets will not b
 | `space[searchblok_id]` | Searchblok id, if available |
 | `space[environments]` | Array of `name` and `location` (url) objects |
 | `dup_id` | The numeric id of the original space |
+| `assign_partner` | Boolean. Whether to create this new space in your partner space, if you are part of one |
 
 ;examplearea
 


### PR DESCRIPTION
When trying to duplicate a space from a current partner space, you get an error 422: "You need to select one of our plans to proceed with the trial period.".

Duplicating a space with `assign_partner: true` will let this go through.

![Warp- te-acceleratorscripts_2024-03-13 at 11 07@2x](https://github.com/storyblok/storyblok-docs/assets/1895120/b7b6ca8f-3c1e-4755-b8e4-10b10be39729)
